### PR TITLE
Keep missing vars

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -114,7 +114,7 @@ def chain_files(db, tmp_path_factory):
 def lifted_scorefiles(scorefiles, chain_files, tmp_path_factory):
     out_path = tmp_path_factory.mktemp("scores") / "lifted.txt"
     args: list[str] = ['combine_scorefiles', '-s'] + scorefiles + ['--liftover', '-c', chain_files, '-t', 'GRCh38',
-                                                                   '-m', '0.95'] + ['-o', str(out_path.resolve())]
+                                                                   '-m', '0.8'] + ['-o', str(out_path.resolve())]
 
     with patch('sys.argv', args):
         combine_scorefiles()

--- a/pgscatalog_utils/download/score.py
+++ b/pgscatalog_utils/download/score.py
@@ -12,7 +12,7 @@ def get_url(pgs: list[str], build: str) -> dict[str, str]:
 
     for chunk in _chunker(pgs):
         try:
-            response = _parse_json_query(_query_score(chunk), build)
+            response = _parse_json_query(query_score(chunk), build)
             pgs_result = pgs_result + list(response.keys())
             url_result = url_result + list(response.values())
         except TypeError:
@@ -27,16 +27,16 @@ def get_url(pgs: list[str], build: str) -> dict[str, str]:
     return dict(zip(pgs_result, url_result))
 
 
-def _chunker(pgs: list[str]):
-    size = 50  # /rest/score/{pgs_id} limit when searching multiple IDs
-    return(pgs[pos: pos + size] for pos in range(0, len(pgs), size))
-
-
-def _query_score(pgs_id: list[str]) -> dict:
+def query_score(pgs_id: list[str]) -> dict:
     pgs: str = ','.join(pgs_id)
     api: str = f'https://www.pgscatalog.org/rest/score/search?pgs_ids={pgs}'
     r: requests.models.Response = requests.get(api)
     return r.json()
+
+
+def _chunker(pgs: list[str]):
+    size = 50  # /rest/score/{pgs_id} limit when searching multiple IDs
+    return(pgs[pos: pos + size] for pos in range(0, len(pgs), size))
 
 
 def _parse_json_query(json: dict, build: str | None) -> dict[str, str]:

--- a/pgscatalog_utils/match/match.py
+++ b/pgscatalog_utils/match/match.py
@@ -16,27 +16,17 @@ def get_all_matches(scorefile: pl.DataFrame, target: pl.DataFrame, remove_ambigu
 
     if scorefile_oa:
         logger.debug("Getting matches for scores with effect allele and other allele")
-        matches.append(_match_variants(scorefile_cat, target_cat, effect_allele='REF', other_allele='ALT',
-                                       match_type="refalt"))
-        matches.append(_match_variants(scorefile_cat, target_cat, effect_allele='ALT', other_allele='REF',
-                                       match_type="altref"))
-        matches.append(_match_variants(scorefile_cat, target_cat, effect_allele='REF_FLIP',
-                                       other_allele='ALT_FLIP',
-                                       match_type="refalt_flip"))
-        matches.append(_match_variants(scorefile_cat, target_cat, effect_allele='ALT_FLIP',
-                                       other_allele='REF_FLIP',
-                                       match_type="altref_flip"))
+        matches.append(_match_variants(scorefile_cat, target_cat, match_type="refalt"))
+        matches.append(_match_variants(scorefile_cat, target_cat, match_type="altref"))
+        matches.append(_match_variants(scorefile_cat, target_cat, match_type="refalt_flip"))
+        matches.append(_match_variants(scorefile_cat, target_cat, match_type="altref_flip"))
 
     if scorefile_no_oa:
         logger.debug("Getting matches for scores with effect allele only")
-        matches.append(_match_variants(scorefile_no_oa, target_cat, effect_allele='REF', other_allele=None,
-                                       match_type="no_oa_ref"))
-        matches.append(_match_variants(scorefile_no_oa, target_cat, effect_allele='ALT', other_allele=None,
-                                       match_type="no_oa_alt"))
-        matches.append(_match_variants(scorefile_no_oa, target_cat, effect_allele='REF_FLIP',
-                                       other_allele=None, match_type="no_oa_ref_flip"))
-        matches.append(_match_variants(scorefile_no_oa, target_cat, effect_allele='ALT_FLIP',
-                                       other_allele=None, match_type="no_oa_alt_flip"))
+        matches.append(_match_variants(scorefile_no_oa, target_cat, match_type="no_oa_ref"))
+        matches.append(_match_variants(scorefile_no_oa, target_cat, match_type="no_oa_alt"))
+        matches.append(_match_variants(scorefile_no_oa, target_cat, match_type="no_oa_ref_flip"))
+        matches.append(_match_variants(scorefile_no_oa, target_cat, match_type="no_oa_alt_flip"))
 
     return pl.concat(matches).pipe(postprocess_matches, remove_ambiguous)
 
@@ -54,9 +44,32 @@ def check_match_rate(scorefile: pl.DataFrame, matches: pl.DataFrame, min_overlap
 
     for accession, rate in zip(fail_rates['accession'].to_list(), fail_rates['fail_rate'].to_list()):
         if rate < (1 - min_overlap):
-            logger.debug(f"Score {accession} passes minimum matching threshold ({1-rate:.2%}  variants match)")
+            logger.debug(f"Score {accession} passes minimum matching threshold ({1 - rate:.2%}  variants match)")
         else:
-            logger.error(f"Score {accession} fails minimum matching threshold ({1-rate:.2%} variants match)")
+            logger.error(f"Score {accession} fails minimum matching threshold ({1 - rate:.2%} variants match)")
+            raise Exception
+
+
+def _get_match_keys(strategy: str) -> tuple[list[str], list[str]]:
+    match strategy:
+        case 'refalt':
+            return _scorefile_keys('effect_allele', 'other_allele'), _target_keys()
+        case 'altref':
+            return _scorefile_keys('other_allele', 'effect_allele'), _target_keys()
+        case 'refalt_flip':
+            return _scorefile_keys('effect_allele_FLIP', 'other_allele_FLIP'), _target_keys()
+        case 'altref_flip':
+            return _scorefile_keys('other_allele_FLIP', 'effect_allele_FLIP'), _target_keys()
+        case 'no_oa_ref':
+            return _scorefile_keys('effect_allele', ''), _target_keys(False)
+        case 'no_oa_alt':
+            return _scorefile_keys('other_allele', ''), _target_keys(False)
+        case 'no_oa_ref_flip':
+            return _scorefile_keys('effect_allele_FLIP', ''), _target_keys(False)
+        case 'no_oa_alt_flip':
+            return _scorefile_keys('other_allele_FLIP', ''), _target_keys(False)
+        case _:
+            logger.critical(f"Invalid match strategy: {strategy}")
             raise Exception
 
 
@@ -71,28 +84,31 @@ def _join_matches(matches: pl.DataFrame, scorefile: pl.DataFrame, dataset: str):
 
 def _match_variants(scorefile: pl.DataFrame,
                     target: pl.DataFrame,
-                    effect_allele: str,
-                    other_allele: str | None,
                     match_type: str) -> pl.DataFrame:
     logger.debug(f"Matching strategy: {match_type}")
+    score_key, target_key = _get_match_keys(match_type)
     return (scorefile.join(target,
-                           left_on=_scorefile_keys(other_allele),
-                           right_on=_target_keys(effect_allele, other_allele),
-                           how='inner')).pipe(_post_match, effect_allele, other_allele, match_type)
+                           left_on=score_key,
+                           right_on=target_key,
+                           how='inner').pipe(_post_match, target_key, match_type))
 
 
 def _post_match(df: pl.DataFrame,
-                effect_allele: str,
-                other_allele: str,
+                target_keys: list[str],
                 match_type: str) -> pl.DataFrame:
     """ Annotate matches with parameters """
-    if other_allele is None:
+    if len(target_keys) == 3:
         logger.debug("Dropping missing other_allele during annotation")
-        other_allele = 'dummy'  # prevent trying to alias a column to None
+        ref_key = target_keys[-1]
+        alt_key = 'dummy'  # prevent trying to alias a column to None
+    else:
+        ref_key = target_keys[-2]
+        alt_key = target_keys[-1]
 
+    # aliases keep a copy of columns dropped during the join
     return df.with_columns([pl.col("*"),
-                            pl.col("effect_allele").alias(effect_allele),
-                            pl.col("other_allele").alias(other_allele),
+                            pl.col("effect_allele").alias(ref_key),
+                            pl.col("other_allele").alias(alt_key),
                             pl.lit(match_type).alias("match_type"),
                             ])[_matched_colnames()]
 
@@ -104,33 +120,33 @@ def _cast_categorical(scorefile, target) -> tuple[pl.DataFrame, pl.DataFrame]:
             pl.col("effect_allele").cast(pl.Categorical),
             pl.col("other_allele").cast(pl.Categorical),
             pl.col("effect_type").cast(pl.Categorical),
+            pl.col("effect_allele_FLIP").cast(pl.Categorical),
+            pl.col("other_allele_FLIP").cast(pl.Categorical),
             pl.col("accession").cast(pl.Categorical)
         ])
     if target:
         target = target.with_columns([
             pl.col("REF").cast(pl.Categorical),
-            pl.col("ALT").cast(pl.Categorical),
-            pl.col("ALT_FLIP").cast(pl.Categorical),
-            pl.col("REF_FLIP").cast(pl.Categorical)
+            pl.col("ALT").cast(pl.Categorical)
         ])
 
     return scorefile, target
 
 
-def _scorefile_keys(other_allele: str) -> list[str]:
-    if other_allele:
-        return ['chr_name', 'chr_position', 'effect_allele', 'other_allele']
+def _scorefile_keys(ref_key: str, alt_key: str) -> list[str]:
+    if alt_key:
+        return ['chr_name', 'chr_position', ref_key, alt_key]
     else:
-        return ['chr_name', 'chr_position', 'effect_allele']
+        return ['chr_name', 'chr_position', ref_key]
 
 
-def _target_keys(effect_allele: str, other_allele: str) -> list[str]:
-    if other_allele:
-        return ['#CHROM', 'POS', effect_allele, other_allele]
+def _target_keys(alt_key: bool = True) -> list[str]:
+    if alt_key:
+        return ['#CHROM', 'POS', "REF", "ALT"]
     else:
-        return ['#CHROM', 'POS', effect_allele]
+        return ['#CHROM', 'POS', "REF"]
 
 
 def _matched_colnames() -> list[str]:
-    return ['chr_name', 'chr_position', 'effect_allele', 'other_allele', 'effect_weight', 'effect_type', 'accession',
-            'ID', 'REF', 'ALT', 'REF_FLIP', 'ALT_FLIP', 'match_type', 'is_multiallelic']
+    return ['chr_name', 'chr_position', 'effect_allele', 'effect_allele_FLIP', 'other_allele', 'other_allele_FLIP',
+            'effect_weight', 'effect_type', 'accession', 'ID', 'REF', 'ALT', 'match_type', 'is_multiallelic']

--- a/pgscatalog_utils/match/match_variants.py
+++ b/pgscatalog_utils/match/match_variants.py
@@ -129,6 +129,9 @@ def _parse_args(args=None):
                              'statistics were used to construct the score.'),
     parser.add_argument('--keep_multiallelic', dest='remove_multiallelic', action='store_false',
                         help='Flag to allow matching to multiallelic variants (default: false).')
+    parser.add_argument('--ignore_strand_flips', dest='consider_strand_flips', action='store_false',
+                        help='Flag to not consider matched variants that may be reported on the opposite strand. '
+                             'Default behaviour is to flip/complement unmatched variants and check if they match.')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help='<Optional> Extra logging information')
     return parser.parse_args(args)

--- a/pgscatalog_utils/match/match_variants.py
+++ b/pgscatalog_utils/match/match_variants.py
@@ -98,7 +98,7 @@ def _match_single_target(target_path: str, scorefile: pl.DataFrame, remove_multi
     matches = []
     for chrom in scorefile['chr_name'].unique().to_list():
         target = read_target(target_path, remove_multiallelic=remove_multiallelic,
-                             singie_file=True, chrom=chrom)  # scans and filters
+                             single_file=True, chrom=chrom)  # scans and filters
         if target:
             logger.debug(f"Matching chromosome {chrom}")
             matches.append(get_all_matches(scorefile, target, remove_ambiguous))

--- a/pgscatalog_utils/match/match_variants.py
+++ b/pgscatalog_utils/match/match_variants.py
@@ -17,7 +17,7 @@ def match_variants():
 
     set_logging_level(args.verbose)
 
-    logger.debug(f"n_threads: {pl.threadpool_size()}")
+    logger.debug(f"polars n_threads: {pl.threadpool_size()}")
     scorefile: pl.DataFrame = read_scorefile(path=args.scorefile)
 
     with pl.StringCache():
@@ -49,6 +49,10 @@ def match_variants():
             case _:
                 logger.critical(f"Invalid match mode: {match_mode}")
                 raise Exception
+
+        if args.skip_flip:
+            logger.debug("Ignoring strand flip matches")
+            matches = _drop_flips(matches)
 
         dataset = args.dataset.replace('_', '-')  # underscores are delimiters in pgs catalog calculator
         check_match_rate(scorefile, matches, args.min_overlap, dataset)
@@ -106,6 +110,10 @@ def _match_single_target(target_path: str, scorefile: pl.DataFrame, remove_multi
     return pl.concat(matches)
 
 
+def _drop_flips(df: pl.DataFrame):
+    return df.filter(pl.col('match_type').str.contains("flip").is_not())
+
+
 def _parse_args(args=None):
     parser = argparse.ArgumentParser(description='Match variants from a combined scoring file against target variants')
     parser.add_argument('-d', '--dataset', dest='dataset', required=True,
@@ -129,7 +137,7 @@ def _parse_args(args=None):
                              'statistics were used to construct the score.'),
     parser.add_argument('--keep_multiallelic', dest='remove_multiallelic', action='store_false',
                         help='Flag to allow matching to multiallelic variants (default: false).')
-    parser.add_argument('--ignore_strand_flips', dest='consider_strand_flips', action='store_false',
+    parser.add_argument('--ignore_strand_flips', dest='skip_flip', action='store_true',
                         help='Flag to not consider matched variants that may be reported on the opposite strand. '
                              'Default behaviour is to flip/complement unmatched variants and check if they match.')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',

--- a/pgscatalog_utils/match/postprocess.py
+++ b/pgscatalog_utils/match/postprocess.py
@@ -24,12 +24,12 @@ def postprocess_matches(df: pl.DataFrame, remove_ambiguous: bool) -> pl.DataFram
 def _label_biallelic_ambiguous(df: pl.DataFrame) -> pl.DataFrame:
     # A / T or C / G may match multiple times
     df = df.with_columns([
-        pl.col(["effect_allele", "other_allele", "REF", "ALT", "REF_FLIP", "ALT_FLIP"]).cast(str),
+        pl.col(["effect_allele", "other_allele", "REF", "ALT", "effect_allele_FLIP", "other_allele_FLIP"]).cast(str),
         pl.lit(True).alias("ambiguous")
     ])
 
     return (df.with_column(
-        pl.when((pl.col("effect_allele") == pl.col("ALT_FLIP")) | (pl.col("effect_allele") == pl.col("REF_FLIP")))
+        pl.when((pl.col("effect_allele_FLIP") == pl.col("ALT")) | (pl.col("effect_allele_FLIP") == pl.col("REF")))
         .then(pl.col("ambiguous"))
         .otherwise(False))).pipe(_get_distinct_weights)
 

--- a/pgscatalog_utils/match/preprocess.py
+++ b/pgscatalog_utils/match/preprocess.py
@@ -38,7 +38,7 @@ def complement_valid_alleles(df: pl.DataFrame, flip_cols = []) -> pl.DataFrame:
     for col in flip_cols:
         new_col = col + '_FLIP'
         df = df.with_column(
-            pl.when(pl.col(col).str.contains('^[ACGT]*$'))
+            pl.when(pl.col(col).str.contains('^[ACGT]+$'))
                 .then(pl.col(col).str.replace_all("A", "V")
                            .str.replace_all("T", "X")
                            .str.replace_all("C", "Y")

--- a/pgscatalog_utils/match/preprocess.py
+++ b/pgscatalog_utils/match/preprocess.py
@@ -4,38 +4,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def ugly_complement(df: pl.DataFrame) -> pl.DataFrame:
-    """ Complementing alleles with a pile of regexes seems weird, but polars string functions are currently limited
-    (i.e. no str.translate). This is fast, and I stole the regex idea from Scott.
-    """
-    logger.debug("Complementing target alleles")
-    return df.with_columns([
-        (pl.col("REF").str.replace_all("A", "V")
-         .str.replace_all("T", "X")
-         .str.replace_all("C", "Y")
-         .str.replace_all("G", "Z")
-         .str.replace_all("V", "T")
-         .str.replace_all("X", "A")
-         .str.replace_all("Y", "G")
-         .str.replace_all("Z", "C"))
-        .alias("REF_FLIP"),
-        (pl.col("ALT").str.replace_all("A", "V")
-         .str.replace_all("T", "X")
-         .str.replace_all("C", "Y")
-         .str.replace_all("G", "Z")
-         .str.replace_all("V", "T")
-         .str.replace_all("X", "A")
-         .str.replace_all("Y", "G")
-         .str.replace_all("Z", "C"))
-        .alias("ALT_FLIP")
-    ])
-
-
-def complement_valid_alleles(df: pl.DataFrame, flip_cols = []) -> pl.DataFrame:
+def complement_valid_alleles(df: pl.DataFrame, flip_cols: list[str]) -> pl.DataFrame:
     """ Improved function to complement alleles. Will only complement sequences that are valid DNA.
-    Uses same method ugly_complement (str.replace_all) above.
     """
     for col in flip_cols:
+        logger.debug(f"Complementing scorefile column {col}")
         new_col = col + '_FLIP'
         df = df.with_column(
             pl.when(pl.col(col).str.contains('^[ACGT]+$'))

--- a/pgscatalog_utils/match/preprocess.py
+++ b/pgscatalog_utils/match/preprocess.py
@@ -31,6 +31,28 @@ def ugly_complement(df: pl.DataFrame) -> pl.DataFrame:
     ])
 
 
+def complement_valid_alleles(df: pl.DataFrame, flip_cols = []) -> pl.DataFrame:
+    """ Improved function to complement alleles. Will only complement sequences that are valid DNA.
+    Uses same method ugly_complement (str.replace_all) above.
+    """
+    for col in flip_cols:
+        new_col = col + '_FLIP'
+        df = df.with_column(
+            pl.when(pl.col(col).str.contains('^[ACGT]*$'))
+                .then(pl.col(col).str.replace_all("A", "V")
+                           .str.replace_all("T", "X")
+                           .str.replace_all("C", "Y")
+                           .str.replace_all("G", "Z")
+                           .str.replace_all("V", "T")
+                           .str.replace_all("X", "A")
+                           .str.replace_all("Y", "G")
+                           .str.replace_all("Z", "C"))
+                .otherwise(pl.col(col))
+                .alias(new_col)
+        )
+    return df
+
+
 def handle_multiallelic(df: pl.DataFrame, remove_multiallelic: bool, pvar: bool) -> pl.DataFrame:
     # plink2 pvar multi-alleles are comma-separated
     df: pl.DataFrame = (df.with_column(

--- a/pgscatalog_utils/match/read.py
+++ b/pgscatalog_utils/match/read.py
@@ -9,13 +9,13 @@ from pgscatalog_utils.match.preprocess import ugly_complement, handle_multiallel
 logger = logging.getLogger(__name__)
 
 
-def read_target(path: str, remove_multiallelic: bool, singie_file: bool = False,
+def read_target(path: str, remove_multiallelic: bool, single_file: bool = False,
                 chrom: str = "") -> pl.DataFrame:
     target: Target = _detect_target_format(path)
     d = {'column_1': str}  # column_1 is always CHROM. CHROM must always be a string
     logger.debug(f"Reading target {path}")
 
-    if singie_file:
+    if single_file:
         logger.debug(f"Scanning target genome for chromosome {chrom}")
         # scan target and filter to reduce memory usage on big files
         df: pl.DataFrame = (

--- a/pgscatalog_utils/match/read.py
+++ b/pgscatalog_utils/match/read.py
@@ -34,10 +34,10 @@ def read_target(path: str, remove_multiallelic: bool, single_file: bool = False,
     match target.file_format:
         case 'bim':
             return (df[_default_cols()]
-                    .pipe(handle_multiallelic, remove_multiallelic=remove_multiallelic, pvar=False)
+                    .pipe(handle_multiallelic, remove_multiallelic=remove_multiallelic, pvar=False))
         case 'pvar':
             return (df[_default_cols()]
-                    .pipe(handle_multiallelic, remove_multiallelic=remove_multiallelic, pvar=True)
+                    .pipe(handle_multiallelic, remove_multiallelic=remove_multiallelic, pvar=True))
         case _:
             logger.error("Invalid file format detected")
             raise Exception
@@ -45,9 +45,8 @@ def read_target(path: str, remove_multiallelic: bool, single_file: bool = False,
 
 def read_scorefile(path: str) -> pl.DataFrame:
     logger.debug("Reading scorefile")
-    scorefile: pl.DataFrame = pl.read_csv(path, sep='\t', dtype={'chr_name': str}).pipe(complement_valid_alleles,
-                                                                                        flip_cols=['effect_allele',
-                                                                                                   'other_allele'])
+    scorefile: pl.DataFrame = (pl.read_csv(path, sep='\t', dtype={'chr_name': str})
+                               .pipe(complement_valid_alleles, flip_cols=['effect_allele', 'other_allele']))
     check_weights(scorefile)
     return scorefile
 

--- a/pgscatalog_utils/scorefile/liftover.py
+++ b/pgscatalog_utils/scorefile/liftover.py
@@ -62,12 +62,14 @@ def _check_min_liftover(mapped: pd.DataFrame, unmapped: pd.DataFrame, min_lift: 
 
 def _convert_coordinates(df: pd.Series, lo_dict: dict[str, pyliftover.LiftOver]) -> pd.Series:
     """ Convert genomic coordinates to different build """
-
-    lo = lo_dict[df['genome_build'] + df['target_build']]  # extract lo object from dict
-    chrom: str = 'chr' + str(df['chr_name'])
-    pos: int = int(df['chr_position']) - 1  # liftOver is 0 indexed, VCF is 1 indexed
-    # converted example: [('chr22', 15460378, '+', 3320966530)] or None
-    converted: list[tuple[str, int, str, int] | None] = lo.convert_coordinate(chrom, pos)
+    if df[['chr_name', 'chr_position']].isnull().values.any():
+        converted = None
+    else:
+        lo = lo_dict[df['genome_build'] + df['target_build']]  # extract lo object from dict
+        chrom: str = 'chr' + str(df['chr_name'])
+        pos: int = int(df['chr_position']) - 1  # liftOver is 0 indexed, VCF is 1 indexed
+        # converted example: [('chr22', 15460378, '+', 3320966530)] or None
+        converted: list[tuple[str, int, str, int] | None] = lo.convert_coordinate(chrom, pos)
 
     if converted:
         lifted_chrom: str = _parse_lifted_chrom(converted[0][0][3:])  # return first matching liftover

--- a/pgscatalog_utils/scorefile/qc.py
+++ b/pgscatalog_utils/scorefile/qc.py
@@ -4,15 +4,19 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def quality_control(df: pd.DataFrame) -> pd.DataFrame:
+def quality_control(df: pd.DataFrame, drop_missing: bool) -> pd.DataFrame:
     """ Do quality control checks on a scorefile """
     _check_shape(df)
     _check_columns(df)
     logger.debug("Quality control: checking for bad variants")
-    return (df.pipe(_drop_hla)
-            .pipe(_drop_missing_variants)
-            .pipe(_check_duplicate_identifiers)
-            .pipe(_drop_multiple_oa))
+    if drop_missing is True:
+        return (df.pipe(_drop_hla)
+                .pipe(_drop_missing_variants)
+                .pipe(_check_duplicate_identifiers)
+                .pipe(_drop_multiple_oa))
+    else:
+        return (df.pipe(_check_duplicate_identifiers)
+                .pipe(_drop_multiple_oa))
 
 
 def _drop_multiple_oa(df: pd.DataFrame) -> pd.DataFrame:

--- a/pgscatalog_utils/scorefile/read.py
+++ b/pgscatalog_utils/scorefile/read.py
@@ -7,13 +7,13 @@ from .qc import quality_control
 logger = logging.getLogger(__name__)
 
 
-def load_scorefile(path: str, use_harmonised: bool = True) -> pd.DataFrame:
+def load_scorefile(path: str, use_harmonised: bool = True, drop_missing: bool = False) -> pd.DataFrame:
     logger.debug(f'Reading scorefile {path}')
     return (pd.read_table(path, dtype=_scorefile_dtypes(), comment='#', na_values=['None'], low_memory=False)
             .pipe(remap_harmonised, use_harmonised=use_harmonised)
             .assign(filename_prefix=_get_basename(path),
                     filename=path)
-            .pipe(quality_control))
+            .pipe(quality_control, drop_missing=drop_missing))
 
 
 def _scorefile_dtypes() -> dict[str]:

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,14 +1,24 @@
 import pandas as pd
+import pytest
+import jq
+
+from pgscatalog_utils.download.score import query_score
 
 
-def test_combine_scorefiles(combined_scorefile):
+def test_combine_scorefiles(combined_scorefile, _n_variants):
     df = pd.read_table(combined_scorefile)
     cols = {'chr_name', 'chr_position', 'effect_allele', 'other_allele', 'effect_weight', 'effect_type', 'accession'}
     assert set(df.columns).issubset(cols)
-    assert df.shape[0] == 51215  # combined number of variants
+    assert df.shape[0] == _n_variants
 
 
 def test_liftover(lifted_scorefiles):
     df = pd.read_table(lifted_scorefiles)
     assert df.shape[0] > 50000  # approx size
 
+
+@pytest.fixture
+def _n_variants(pgs_accessions):
+    json = query_score(pgs_accessions)
+    n: list[int] = jq.compile("[.results][][].variants_number").input(json).all()
+    return sum(n)


### PR DESCRIPTION
The denominator of the scoring files (number of variants) will be incorrect in match_variants if we don't keep all variants from the original scoring file in the combined .txt file. This PR adapts combine_scorefiles to account for this. 

Still ToDo:
- Update match_variants to only flip variants of the scorefile that have not been matched on the forward strand of the target data.