### PR TITLE
Track/Flag duplicated variants

### DIFF
--- a/pgscatalog_utils/match/match.py
+++ b/pgscatalog_utils/match/match.py
@@ -65,8 +65,6 @@ def check_match_rate(scorefile: pl.DataFrame, matches: pl.DataFrame, min_overlap
     return (matches.with_column(pl.col('accession').cast(str))
             .join(pass_df, on='accession', how='left'))
 
-
-
 def _match_keys():
     return ['chr_name', 'chr_position', 'effect_allele', 'other_allele',
             'accession', 'effect_type', 'effect_weight']

--- a/pgscatalog_utils/match/match.py
+++ b/pgscatalog_utils/match/match.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_all_matches(scorefile: pl.DataFrame, target: pl.DataFrame, remove_ambiguous: bool,
-                    skip_flip: bool) -> pl.DataFrame:
+                    skip_flip: bool, keep_first_match: bool) -> pl.DataFrame:
     scorefile_cat, target_cat = _cast_categorical(scorefile, target)
     scorefile_oa = scorefile_cat.filter(pl.col("other_allele") != None)
     scorefile_no_oa = scorefile_cat.filter(pl.col("other_allele") == None)
@@ -35,7 +35,7 @@ def get_all_matches(scorefile: pl.DataFrame, target: pl.DataFrame, remove_ambigu
             matches.append(_match_variants(scorefile_no_oa, target_cat, match_type="no_oa_ref_flip").select(col_order))
             matches.append(_match_variants(scorefile_no_oa, target_cat, match_type="no_oa_alt_flip").select(col_order))
 
-    return pl.concat(matches).pipe(postprocess_matches, remove_ambiguous)
+    return pl.concat(matches).pipe(postprocess_matches, remove_ambiguous, keep_first_match)
 
 
 def check_match_rate(scorefile: pl.DataFrame, matches: pl.DataFrame, min_overlap: float, dataset: str) -> pl.DataFrame:
@@ -58,12 +58,16 @@ def check_match_rate(scorefile: pl.DataFrame, matches: pl.DataFrame, min_overlap
             pass_df = pl.concat([pass_df, df])
             logger.error(f"Score {accession} fails minimum matching threshold ({1 - rate:.2%} variants match)")
 
+    # TODO: fill nulls in certain columns with false in a nicer way
+    match_log['passes_pruning'] = match_log['passes_pruning'].fill_null(False)
+
     # add match statistics to log and matches
     write_log((match_log.with_column(pl.col('accession').cast(str))
                .join(pass_df, on='accession', how='left')), dataset)
 
     return (matches.with_column(pl.col('accession').cast(str))
             .join(pass_df, on='accession', how='left'))
+
 
 def _match_keys():
     return ['chr_name', 'chr_position', 'effect_allele', 'other_allele',

--- a/pgscatalog_utils/match/postprocess.py
+++ b/pgscatalog_utils/match/postprocess.py
@@ -7,8 +7,15 @@ from pgscatalog_utils.match.preprocess import complement_valid_alleles
 logger = logging.getLogger(__name__)
 
 
-def postprocess_matches(df: pl.DataFrame, remove_ambiguous: bool) -> pl.DataFrame:
-    df = _label_biallelic_ambiguous(df)
+def postprocess_matches(df: pl.DataFrame, remove_ambiguous: bool, keep_first_match: bool) -> pl.DataFrame:
+    """ Clean up match candidates ready for writing out, including:
+
+    - Label ambiguous variants
+    - Prune match candidates to select the best match for each variant in the scoring file
+    - Optionally remove ambiguous variants
+    """
+    df = _label_biallelic_ambiguous(df).pipe(_prune_matches, keep_first_match)
+
     if remove_ambiguous:
         logger.debug("Removing ambiguous matches")
         return df.filter(pl.col("ambiguous") == False)
@@ -30,11 +37,23 @@ def _label_biallelic_ambiguous(df: pl.DataFrame) -> pl.DataFrame:
     return (df.with_column(
         pl.when(pl.col("REF_FLIP") == pl.col("ALT"))
         .then(pl.col("ambiguous"))
-        .otherwise(False))).pipe(_prune_matches)
+        .otherwise(False)))
 
 
-def _prune_matches(df: pl.DataFrame) -> pl.DataFrame:
-    """ Select single matched variant in target for each variant in the scoring file (e.g. per accession) """
+def _prune_matches(df: pl.DataFrame, keep_first_match: bool = True) -> pl.DataFrame:
+    """ Select the best match candidate in the target for each variant in the scoring file
+
+    - In a scoring file (accession), each variant ID with the same effect allele and weight *must be unique*
+    - The variant matching process normally returns multiple match candidates for each variant ID, e.g.:
+        refalt > altref > refalt_flip > altref_flip
+    - When multiple match candidates for an ID exist, they must be prioritised and pruned to be unique
+    - If it's impossible to prioritise match candidates (i.e. same strategy is used), drop all matches by default
+
+    :param df: A dataframe containing multiple match candidates for each variant
+    :param drop_duplicates: If it's impossible to make match candidates unique, drop all candidates?
+    :return: A dataframe containing the best match candidate for each variant
+    """
+
     dups: pl.DataFrame = _get_duplicate_variants(df)
 
     if dups:
@@ -42,12 +61,15 @@ def _prune_matches(df: pl.DataFrame) -> pl.DataFrame:
         singletons: pl.DataFrame = _get_singleton_variants(df)
         prioritised: pl.DataFrame = _prioritise_match_type(dups)
         prioritised_dups: pl.DataFrame = _get_duplicate_variants(prioritised)
-        if prioritised_dups:
-            logger.debug("Final match pruning: dropping any duplicates remaining")
-            prioritised_singletons: pl.DataFrame = _get_singleton_variants(prioritised)
-            distinct: pl.DataFrame = pl.concat([singletons, prioritised_singletons])
+        if prioritised_dups and not keep_first_match:
+            logger.debug("Final match pruning: dropping remaining duplicate matches")
+            distinct: pl.DataFrame = pl.concat([singletons, _get_singleton_variants(prioritised)])
+        elif prioritised_dups and keep_first_match:
+            logger.debug("Final match pruning: keeping first match")
+            distinct: pl.DataFrame = pl.concat([singletons, _get_singleton_variants(prioritised),
+                                                prioritised.unique(maintain_order=True)])
         else:
-            logger.debug("Final match pruning skipped (not required)")
+            logger.debug("Final match pruning unnecessary")
             distinct: pl.DataFrame = pl.concat([singletons, prioritised])
     else:
         distinct: pl.DataFrame = df
@@ -55,10 +77,11 @@ def _prune_matches(df: pl.DataFrame) -> pl.DataFrame:
     assert all(distinct.groupby(['accession', 'ID']).count()['count'] == 1), "Duplicate effect weights for a variant"
     logger.debug("Match pruning complete")
 
-    return distinct
+    return distinct.with_column(pl.lit(True).alias('passes_pruning'))
 
 
 def _get_singleton_variants(df: pl.DataFrame) -> pl.DataFrame:
+    """ Return variants with only one row (match candidate) per variant ID """
     return (df.groupby(['accession', 'chr_name', 'chr_position', 'effect_allele'])
             .count()
             .filter(pl.col('count') == 1)[:, "accession":"effect_allele"]
@@ -66,6 +89,7 @@ def _get_singleton_variants(df: pl.DataFrame) -> pl.DataFrame:
 
 
 def _get_duplicate_variants(df: pl.DataFrame) -> pl.DataFrame:
+    """ Return variants with more than one row (match candidate) per variant ID """
     return (df.groupby(['accession', 'chr_name', 'chr_position', 'effect_allele'])
             .count()
             .filter(pl.col('count') > 1)[:, "accession":"effect_allele"]

--- a/pgscatalog_utils/match/preprocess.py
+++ b/pgscatalog_utils/match/preprocess.py
@@ -51,13 +51,5 @@ def handle_multiallelic(df: pl.DataFrame, remove_multiallelic: bool, pvar: bool)
         return df
 
 
-def check_weights(df: pl.DataFrame) -> None:
-    """ Checks weights for scoring file variants that could be matched (e.g. have a chr & pos) """
-    weight_count = df.filter(pl.col('chr_name').is_not_null() & pl.col('chr_position').is_not_null()).groupby(['accession', 'chr_name', 'chr_position', 'effect_allele']).count()
-    if any(weight_count['count'] > 1):
-        logger.error("Multiple effect weights per variant per accession detected in files: {}".format(list(weight_count.filter(pl.col('count') > 1)['accession'].unique())))
-        raise Exception
-
-
 def _annotate_multiallelic(df: pl.DataFrame) -> pl.DataFrame:
     df.with_column(pl.when(pl.col("ALT").str.contains(',')).then(pl.lit(True)).otherwise(pl.lit(False)).alias('is_multiallelic'))

--- a/pgscatalog_utils/match/read.py
+++ b/pgscatalog_utils/match/read.py
@@ -4,7 +4,7 @@ from typing import NamedTuple
 
 import polars as pl
 
-from pgscatalog_utils.match.preprocess import handle_multiallelic, check_weights, complement_valid_alleles
+from pgscatalog_utils.match.preprocess import handle_multiallelic, complement_valid_alleles
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +33,12 @@ def read_target(path: str, remove_multiallelic: bool, single_file: bool = False,
 
     match target.file_format:
         case 'bim':
-            return (df[_default_cols()]
+            return (df.select(_default_cols())
+                    .filter(pl.col('ID') != '.')  # remove missing IDs
                     .pipe(handle_multiallelic, remove_multiallelic=remove_multiallelic, pvar=False))
         case 'pvar':
-            return (df[_default_cols()]
+            return (df.select(_default_cols())
+                    .filter(pl.col('ID') != '.')
                     .pipe(handle_multiallelic, remove_multiallelic=remove_multiallelic, pvar=True))
         case _:
             logger.error("Invalid file format detected")
@@ -47,7 +49,6 @@ def read_scorefile(path: str) -> pl.DataFrame:
     logger.debug("Reading scorefile")
     scorefile: pl.DataFrame = (pl.read_csv(path, sep='\t', dtype={'chr_name': str})
                                .pipe(complement_valid_alleles, flip_cols=['effect_allele', 'other_allele']))
-    check_weights(scorefile)
     return scorefile
 
 

--- a/pgscatalog_utils/scorefile/combine_scorefiles.py
+++ b/pgscatalog_utils/scorefile/combine_scorefiles.py
@@ -43,19 +43,21 @@ if __name__ == "__main__":
 
 def _description_text() -> str:
     return textwrap.dedent('''\
-    Combine multiple scoring files in PGS Catalog format (see 
-    https://www.pgscatalog.org/downloads/ for details) to a 'long'
-    table, and optionally liftover genomic coordinates to GRCh37 or
-    GRCh38. Custom scorefiles in PGS Catalog format can be combined
-    with PGS Catalog scoring files. The program can accept a mix of
-    unharmonised and harmonised PGS Catalog data.     
+    Combine multiple scoring files in PGS Catalog format (see https://www.pgscatalog.org/downloads/ 
+    for details) to a 'long' table of columns needed for variant matching and subsequent calculation. 
+    
+    Custom scorefiles in PGS Catalog format can be combined with PGS Catalog scoring files, and 
+    optionally liftover genomic coordinates to GRCh37 or GRCh38. The script can accept a mix of
+    unharmonised and harmonised PGS Catalog data. By default all variants are output (including 
+    positions with duplicated data [often caused by rsID/liftover collions across builds]) and 
+    variants with missing positions. 
     ''')
 
 
 def _epilog_text() -> str:
     return textwrap.dedent('''\
-    The long table is used to simplify intersecting variants in target
-    genomes and the scoring files with the match_variants program.    
+    The long table is used to simplify intersecting variants in target genotyping datasets 
+    and the scoring files with the match_variants program.
     ''')
 
 

--- a/pgscatalog_utils/scorefile/combine_scorefiles.py
+++ b/pgscatalog_utils/scorefile/combine_scorefiles.py
@@ -79,9 +79,9 @@ def _parse_args(args=None) -> argparse.Namespace:
                         help='Drop variants with missing information (chr/pos) and '
                              'non-standard alleles (e.g. HLA=P/N) from the output file.')
     parser.add_argument('-o', '--outfile', dest='outfile', required=True,
-                        help='[ will compress output if filename ends with .gz ]',
                         default='combined.txt',
-                        help='<Required> Output path to combined long scorefile')
+                        help='<Required> Output path to combined long scorefile '
+                             '[ will compress output if filename ends with .gz ]')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help='<Optional> Extra logging information')
     return parser.parse_args(args)

--- a/pgscatalog_utils/scorefile/combine_scorefiles.py
+++ b/pgscatalog_utils/scorefile/combine_scorefiles.py
@@ -77,7 +77,7 @@ def _parse_args(args=None) -> argparse.Namespace:
                         required="--liftover" in sys.argv, default=0.95, type=float)
     parser.add_argument('--drop_missing', dest='drop_missing', action='store_true',
                         help='Drop variants with missing information (chr/pos) and '
-                             'non-standard alleles from the output file.')
+                             'non-standard alleles (e.g. HLA=P/N) from the output file.')
     parser.add_argument('-o', '--outfile', dest='outfile', required=True,
                         default='combined.txt',
                         help='<Required> Output path to combined long scorefile')

--- a/pgscatalog_utils/scorefile/combine_scorefiles.py
+++ b/pgscatalog_utils/scorefile/combine_scorefiles.py
@@ -79,6 +79,7 @@ def _parse_args(args=None) -> argparse.Namespace:
                         help='Drop variants with missing information (chr/pos) and '
                              'non-standard alleles (e.g. HLA=P/N) from the output file.')
     parser.add_argument('-o', '--outfile', dest='outfile', required=True,
+                        help='[ will compress output if filename ends with .gz ]',
                         default='combined.txt',
                         help='<Required> Output path to combined long scorefile')
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',

--- a/pgscatalog_utils/scorefile/qc.py
+++ b/pgscatalog_utils/scorefile/qc.py
@@ -71,7 +71,7 @@ def _check_duplicate_identifiers(df: pd.DataFrame) -> pd.DataFrame:
     if unique.all():
         return df
     else:
-        raise Exception("Duplicate variants in scoring file")
+        logger.warning("Duplicate variants in scoring file.")
 
 
 def _check_shape(df: pd.DataFrame) -> None:

--- a/pgscatalog_utils/scorefile/qc.py
+++ b/pgscatalog_utils/scorefile/qc.py
@@ -71,7 +71,7 @@ def _check_duplicate_identifiers(df: pd.DataFrame) -> pd.DataFrame:
     if all(u_count == 1):
         return df.assign(is_duplicated=False)
     else:
-        logger.warning("Duplicate variants in scoring file.")
+        logger.warning("Duplicate variants in scoring file: {}".format(df['filename_prefix'].unique()))
         u_count = u_count > 1
         u_count.name = 'is_duplicated'
         df = pd.merge(df, u_count, how='left', left_on=group_cols, right_index=True)

--- a/pgscatalog_utils/scorefile/qc.py
+++ b/pgscatalog_utils/scorefile/qc.py
@@ -72,6 +72,7 @@ def _check_duplicate_identifiers(df: pd.DataFrame) -> pd.DataFrame:
         return df
     else:
         logger.warning("Duplicate variants in scoring file.")
+        return df
 
 
 def _check_shape(df: pd.DataFrame) -> None:

--- a/pgscatalog_utils/scorefile/qc.py
+++ b/pgscatalog_utils/scorefile/qc.py
@@ -75,8 +75,9 @@ def _check_duplicate_identifiers(df: pd.DataFrame) -> pd.DataFrame:
         u_count = u_count > 1
         u_count.name = 'is_duplicated'
         df = pd.merge(df, u_count, how='left', left_on=group_cols, right_index=True)
-        df.loc[df.is_duplicated.isnull(), 'is_duplicated'] = False # handles variants with null chr/pos
+        df.loc[df.is_duplicated.isnull(), 'is_duplicated'] = False  # handles variants with null chr/pos
         return df
+
 
 def _check_shape(df: pd.DataFrame) -> None:
     assert len(df.columns) > 1, "ERROR: scorefile not formatted correctly (0 columns)"

--- a/pgscatalog_utils/scorefile/qc.py
+++ b/pgscatalog_utils/scorefile/qc.py
@@ -74,7 +74,9 @@ def _check_duplicate_identifiers(df: pd.DataFrame) -> pd.DataFrame:
         logger.warning("Duplicate variants in scoring file.")
         u_count = u_count > 1
         u_count.name = 'is_duplicated'
-        return pd.merge(df, u_count, how='left', left_on=group_cols, right_index=True)
+        df = pd.merge(df, u_count, how='left', left_on=group_cols, right_index=True)
+        df.loc[df.is_duplicated.isnull(), 'is_duplicated'] = False # handles variants with null chr/pos
+        return df
 
 def _check_shape(df: pd.DataFrame) -> None:
     assert len(df.columns) > 1, "ERROR: scorefile not formatted correctly (0 columns)"

--- a/pgscatalog_utils/scorefile/write.py
+++ b/pgscatalog_utils/scorefile/write.py
@@ -13,7 +13,6 @@ def write_scorefile(df: pd.DataFrame, path: str) -> None:
         logger.error("Empty scorefile output! Please check the input data")
         raise Exception
     else:
-        logger.debug("Writing out combined scorefile")
         out_df: pd.DataFrame = (df.drop('accession', axis=1)
                                 .rename({'filename_prefix': 'accession'}, axis=1)
                                 .pipe(_filter_failed_liftover))
@@ -21,8 +20,12 @@ def write_scorefile(df: pd.DataFrame, path: str) -> None:
         if 'other_allele' not in out_df:
             logger.warning("No other allele information detected, writing out as missing data")
             out_df['other_allele'] = None
-
-        out_df[cols].to_csv(path, index=False, sep="\t")
+        if path.endswith('.gz'):
+            logger.debug("Writing out gzip-compressed combined scorefile")
+            out_df[cols].to_csv(path, index=False, sep="\t", compression='gzip')
+        else:
+            logger.debug("Writing out combined scorefile")
+            out_df[cols].to_csv(path, index=False, sep="\t")
 
 
 def _filter_failed_liftover(df: pd.DataFrame) -> pd.DataFrame:

--- a/pgscatalog_utils/scorefile/write.py
+++ b/pgscatalog_utils/scorefile/write.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def write_scorefile(df: pd.DataFrame, path: str) -> None:
     cols: list[str] = ['chr_name', 'chr_position', 'effect_allele', 'other_allele', 'effect_weight', 'effect_type',
-                       'accession']
+                       'is_duplicated', 'accession']
 
     if df.empty:
         logger.error("Empty scorefile output! Please check the input data")

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -7,7 +7,8 @@ from pgscatalog_utils.download.score import query_score
 
 def test_combine_scorefiles(combined_scorefile, _n_variants):
     df = pd.read_table(combined_scorefile)
-    cols = {'chr_name', 'chr_position', 'effect_allele', 'other_allele', 'effect_weight', 'effect_type', 'accession'}
+    cols = {'chr_name', 'chr_position', 'effect_allele', 'other_allele', 'effect_weight', 'effect_type',
+            'is_duplicated', 'accession'}
     assert set(df.columns).issubset(cols)
     assert df.shape[0] == _n_variants
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -46,14 +46,14 @@ def test_match_strategies(small_scorefile, small_target):
     scorefile, target = _cast_cat(small_scorefile, small_target)
 
     # check unambiguous matches
-    df = get_all_matches(scorefile, target, remove_ambiguous=True, skip_flip=True)
+    df = get_all_matches(scorefile, target, remove_ambiguous=True, skip_flip=True, keep_first_match=False)
     assert set(df['ID'].to_list()).issubset({'3:3:T:G', '1:1:A:C'})
     assert set(df['match_type'].to_list()).issubset(['altref', 'refalt'])
 
     # when keeping ambiguous and flipping alleles:
     #   2:2:T:A is ambiguous, and matches 'altref' and 'refalt_flip'
     # flipped matches should be dropped for ambiguous matches
-    flip = (get_all_matches(scorefile, target, remove_ambiguous=False, skip_flip=False)\
+    flip = (get_all_matches(scorefile, target, remove_ambiguous=False, skip_flip=False, keep_first_match=False)\
         .filter(pl.col('ambiguous') == True))
     assert set(flip['ID'].to_list()).issubset({'2:2:T:A'})
     assert set(flip['match_type'].to_list()).issubset({'altref'})
@@ -62,12 +62,12 @@ def test_match_strategies(small_scorefile, small_target):
 def test_no_oa_match(small_scorefile_no_oa, small_target):
     scorefile, target = _cast_cat(small_scorefile_no_oa, small_target)
 
-    df = get_all_matches(scorefile, target, remove_ambiguous=True,skip_flip=True)
+    df = get_all_matches(scorefile, target, remove_ambiguous=True,skip_flip=True, keep_first_match=False)
     assert set(df['ID'].to_list()).issubset(['3:3:T:G', '1:1:A:C'])
     assert set(df['match_type'].to_list()).issubset(['no_oa_alt', 'no_oa_ref'])
 
     # one of the matches is ambiguous
-    flip = (get_all_matches(scorefile, target, remove_ambiguous=False, skip_flip=False)
+    flip = (get_all_matches(scorefile, target, remove_ambiguous=False, skip_flip=False, keep_first_match=False)
             .filter(pl.col('ambiguous') == True))
     assert set(flip['ID'].to_list()).issubset({'2:2:T:A'})
     assert set(flip['match_type'].to_list()).issubset({'no_oa_alt'})
@@ -76,14 +76,14 @@ def test_no_oa_match(small_scorefile_no_oa, small_target):
 def test_flip_match(small_flipped_scorefile, small_target):
     scorefile, target = _cast_cat(small_flipped_scorefile, small_target)
 
-    df = get_all_matches(scorefile, target, remove_ambiguous=True, skip_flip=True)
+    df = get_all_matches(scorefile, target, remove_ambiguous=True, skip_flip=True, keep_first_match=False)
     assert df.is_empty()
 
-    flip = get_all_matches(scorefile, target, remove_ambiguous=True, skip_flip=False)
+    flip = get_all_matches(scorefile, target, remove_ambiguous=True, skip_flip=False, keep_first_match=False)
     assert flip['match_type'].str.contains('flip').all()
     assert set(flip['ID'].to_list()).issubset(['3:3:T:G', '1:1:A:C'])
 
-    flip_ambig = (get_all_matches(scorefile, target, remove_ambiguous=False, skip_flip=False)
+    flip_ambig = (get_all_matches(scorefile, target, remove_ambiguous=False, skip_flip=False, keep_first_match=False)
                   .filter(pl.col('ambiguous') == True))
     assert not flip_ambig['match_type'].str.contains('flip').any()  # no flip matches for ambiguous
 


### PR DESCRIPTION
Changes to `combine_scorefiles`:
- Flags duplicated variants in a new column `is_duplicated`
- Implements output compression if the filename ends with `.gz`

This breaks check_weights in match/preprocess.py 