### PR TITLE
checksum computation path fix

### DIFF
--- a/pgscatalog_utils/download/ScoringFileChecksum.py
+++ b/pgscatalog_utils/download/ScoringFileChecksum.py
@@ -15,7 +15,7 @@ def _generate_md5_checksum(filename: str, blocksize=4096) -> typing.Union[str, N
     """ Returns MD5 checksum for the given file. """
     md5 = hashlib.md5()
     try:
-        file = open(filename, 'rb')
+        file = open(config.OUTDIR.joinpath(filename), 'rb')
         with file:
             for block in iter(lambda: file.read(blocksize), b""):
                 md5.update(block)


### PR DESCRIPTION
hello,

not sure if you want pull requests. I found a bug that currently the `download_scorefiles` cant download into a folder as the checksums are computed for the filename and not the path. 

As such this command fails:

```sh
mkdir anyfolder
download_scorefiles -i PGS000922 -o anyfolder/ -b GRCh37
```

With the output:

```
pgscatalog_utils.download.ScoringFileChecksum: 2023-08-25 15:50:13 WARNING  File PGS000922_hmPOS_GRCh37.txt.gz not found!
pgscatalog_utils.download.ScoringFileDownloader: 2023-08-25 15:50:13 WARNING  Scoring file PGS000922_hmPOS_GRCh37.txt.gz fails validation
pgscatalog_utils.download.ScoringFileDownloader: 2023-08-25 15:50:13 WARNING  Remote checksum: 1c59a24ea5ef65a10db2531ba106d5be
pgscatalog_utils.download.ScoringFileDownloader: 2023-08-25 15:50:13 WARNING  Local checksum: None
pgscatalog_utils.download.download_file: 2023-08-25 15:50:13 WARNING  /home/paul/software/pgscatalog_utils/anyfolder/PGS000922_hmPOS_GRCh37.txt.gz exists and overwrite is false, skipping download
pgscatalog_utils.download.ScoringFileChecksum: 2023-08-25 15:50:13 WARNING  File PGS000922_hmPOS_GRCh37.txt.gz not found!
pgscatalog_utils.download.download_file: 2023-08-25 15:50:13 WARNING  /home/paul/software/pgscatalog_utils/anyfolder/PGS000922_hmPOS_GRCh37.txt.gz.md5 exists and overwrite is false, skipping download
pgscatalog_utils.download.download_file: 2023-08-25 15:50:13 WARNING  /home/paul/software/pgscatalog_utils/anyfolder/PGS000922_hmPOS_GRCh37.txt.gz exists and overwrite is false, skipping download
pgscatalog_utils.download.ScoringFileChecksum: 2023-08-25 15:50:13 WARNING  File PGS000922_hmPOS_GRCh37.txt.gz not found!
pgscatalog_utils.download.download_file: 2023-08-25 15:50:13 WARNING  /home/paul/software/pgscatalog_utils/anyfolder/PGS000922_hmPOS_GRCh37.txt.gz.md5 exists and overwrite is false, skipping download
pgscatalog_utils.download.download_file: 2023-08-25 15:50:13 WARNING  /home/paul/software/pgscatalog_utils/anyfolder/PGS000922_hmPOS_GRCh37.txt.gz exists and overwrite is false, skipping download
pgscatalog_utils.download.ScoringFileChecksum: 2023-08-25 15:50:13 WARNING  File PGS000922_hmPOS_GRCh37.txt.gz not found!
pgscatalog_utils.download.download_file: 2023-08-25 15:50:13 WARNING  /home/paul/software/pgscatalog_utils/anyfolder/PGS000922_hmPOS_GRCh37.txt.gz.md5 exists and overwrite is false, skipping download
```

This fixes it hopefully as expected. 

after the fix the output I see is as expected:

```
$ download_scorefiles -i PGS000922 -o anyfolder/ -b GRCh37
$ tree anyfolder
anyfolder
├── PGS000922_hmPOS_GRCh37.txt.gz
└── PGS000922_hmPOS_GRCh37.txt.gz.md5

1 directory, 2 files
```
